### PR TITLE
Adds formatting for backtick strings

### DIFF
--- a/spec/lib/rufo/formatter_source_specs/backtick_strings.rb.spec
+++ b/spec/lib/rufo/formatter_source_specs/backtick_strings.rb.spec
@@ -1,4 +1,4 @@
-#~# ORIGINAL 
+#~# ORIGINAL backtick_strings
 
 `cat meow`
 
@@ -6,7 +6,7 @@
 
 `cat meow`
 
-#~# ORIGINAL 
+#~# ORIGINAL %x()
 
  %x( cat meow )
 

--- a/spec/lib/rufo/new_formatter_spec.rb
+++ b/spec/lib/rufo/new_formatter_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Rufo::NewFormatter do
     assert_source_specs(source_specs) if File.file?(source_specs)
   end
 
-  %w(array_literal hash_literal and_or_not assignment_operators assignments).each do |source_spec_name|
+  %w(backtick_strings).each do |source_spec_name|
     file = File.join(NEW_FORMATTER_FILE_PATH, "/formatter_source_specs/#{source_spec_name}.rb.spec")
     fail "missing #{source_spec_name}" unless File.exist?(file)
     assert_source_specs(file) if File.file?(file)


### PR DESCRIPTION
Adds formatting for backtick strings and %x().

```
#~# ORIGINAL backtick_strings

`cat meow`

#~# EXPECTED

`cat meow`

#~# ORIGINAL %x()

 %x( cat meow )

#~# EXPECTED

%x( cat meow )
```

**Of Note**:

Previously `Rufo::Formatter#visit_string_literal_end` was condensed down into `Rufo::NewFormatter#visit_string_literal` since there were only a few bits needed at the time. Now that we need more of it, I pulled the relevant bits out of `Rufo::NewFormatter#visit_string_literal` and into `Rufo::NewFormatter#visit_string_literal_end` along with the other necessary bits from the old formatter.